### PR TITLE
Pandas Dataframe Keyword Args passed to Dask Dataframe Apply

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # swifter
 A package which efficiently applies any function to a pandas dataframe or series in the fastest available manner.
 
-*Current version == 0.285*
+*Current version == 0.286*
 
 [![CircleCI](https://circleci.com/gh/jmcarpenter2/swifter/tree/master.svg?style=svg)](https://circleci.com/gh/jmcarpenter2/swifter/tree/master)
 

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## Version 0.286
+Fixed a bug that prevented result_type kwarg from being passed to the dask apply function. Now you can use this functionality and it will rely on dask rather than pandas.
+
+Additionally adjusted the speed estimation for data sets < 25000 rows so that it doesn't spend a lot of time estimating how long to run an apply for on the first 1000 rows when the data set is tiny. We want to asymptote to near-pandas performance even on tiny data sets.
+
 ## Version 0.285
 Uses tqdm.autonotebook to dynamically switch between beautiful notebook progress bar and CLI version of the progress bar
 

--- a/setup.py
+++ b/setup.py
@@ -3,12 +3,12 @@ from distutils.core import setup
 setup(
     name="swifter",
     packages=["swifter"],  # this must be the same as the name above
-    version="0.285",
+    version="0.286",
     description="A package which efficiently applies any function to a pandas dataframe or series in the fastest available manner",
     author="Jason Carpenter",
     author_email="jcarpenter@manifold.ai",
     url="https://github.com/jmcarpenter2/swifter",  # use the URL to the github repo
-    download_url="https://github.com/jmcarpenter2/swifter/archive/0.285.tar.gz",
+    download_url="https://github.com/jmcarpenter2/swifter/archive/0.286.tar.gz",
     keywords=["pandas", "dask", "apply", "function", "parallelize", "vectorize"],
     install_requires=["pandas>=0.23.0", "psutil", "dask[complete]>=0.19.0", "tqdm>=4.27.0", "ipywidgets>=7.0.0", "numba"],
     classifiers=[],

--- a/swifter/__init__.py
+++ b/swifter/__init__.py
@@ -3,4 +3,4 @@
 from .swifter import SeriesAccessor, DataFrameAccessor
 
 __all__ = ["SeriesAccessor, DataFrameAccessor"]
-__version__ = "0.285"
+__version__ = "0.286"


### PR DESCRIPTION
* Passed pandas dataframe keyword args e.g. raw and result_type to dask dataframe apply
* On datasets smaller than 25k rows, we now do pandas time estimation on 1/25 of the data set, rather than hardcoded at 1000 rows