### PR TITLE
Configurable progress bar instances

### DIFF
--- a/swifter/tqdm_dask_progressbar.py
+++ b/swifter/tqdm_dask_progressbar.py
@@ -24,7 +24,9 @@ class TQDMDaskProgressBar(Callback, object):
         self.states = ["ready", "waiting", "running", "finished"]
 
     def _start_state(self, dsk, state):
-        self._tqdm = tqdm(total=sum(len(state[k]) for k in self.states), **self.tqdm_args)
+        kwargs = self.tqdm_args.copy()
+        kwargs['total'] = sum(len(state[k]) for k in self.states)
+        self._tqdm = tqdm(**kwargs)
 
     def _posttask(self, key, result, dsk, state, worker_id):
         self._tqdm.update(1)


### PR DESCRIPTION
I didn't really like how I was forced to have "Pandas Apply" or "Dask Apply" as my output. So I did a thing.

The Dask progress bar enforces it's own total argument, so I had it override anything sent into it.

```
import pandas as pd
import swifter
df = pd.DataFrame([{'a': 1, 'b': 2}, {'c': 3, 'd': 4}])
df.swifter.apply(print)
Pandas Apply: 100%|█████████████████████████| 4/4 [00:00<00:00, 1561.11it/s]

df.swifter.progress_bar(desc='testy!', total=2).apply(print)
testy!: 100%|████████████████████████████████| 2/2 [00:00<00:00, 768.75it/s]
```