### PR TITLE
Fix security vulnerability

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## Version 0.292
+Fix known security vulnerability in parso <= 0.4.0 by requiring parso > 0.4.0
+
 ## Version 0.291
 Change import from tqdm.auto instead of tqdm.autenook. Less warnings will show when importing swifter.
 

--- a/setup.py
+++ b/setup.py
@@ -3,13 +3,13 @@ from distutils.core import setup
 setup(
     name="swifter",
     packages=["swifter"],  # this must be the same as the name above
-    version="0.291",
+    version="0.292",
     description="A package which efficiently applies any function to a pandas dataframe or series in the fastest available manner",
     author="Jason Carpenter",
     author_email="jcarpenter@manifold.ai",
     url="https://github.com/jmcarpenter2/swifter",  # use the URL to the github repo
-    download_url="https://github.com/jmcarpenter2/swifter/archive/0.291.tar.gz",
+    download_url="https://github.com/jmcarpenter2/swifter/archive/0.292.tar.gz",
     keywords=["pandas", "dask", "apply", "function", "parallelize", "vectorize"],
-    install_requires=["pandas>=0.23.0", "psutil", "dask[complete]>=0.19.0", "tqdm>=4.27.0", "ipywidgets>=7.0.0", "numba"],
+    install_requires=["pandas>=0.23.0", "psutil", "dask[complete]>=0.19.0", "tqdm>=4.27.0", "ipywidgets>=7.0.0", "parso>0.4.0", "numba"],
     classifiers=[],
 )

--- a/swifter/__init__.py
+++ b/swifter/__init__.py
@@ -3,4 +3,4 @@
 from .swifter import SeriesAccessor, DataFrameAccessor
 
 __all__ = ["SeriesAccessor, DataFrameAccessor"]
-__version__ = "0.291"
+__version__ = "0.292"


### PR DESCRIPTION
Fix known security vulnerability `parso<=0.4.0` by requiring `parso>0.4.0`