### PR TITLE
Include additional files in sdists

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,5 @@
+include LICENSE
+
+graft assets
+graft docs
+graft examples


### PR DESCRIPTION
The license says all copies of the software must include the license text.  Also include documentation, examples, and assets.