### PR TITLE
Fix issue with integer division in python 2

### DIFF
--- a/swifter/swifter.py
+++ b/swifter/swifter.py
@@ -41,7 +41,7 @@ class _SwifterObject:
     ):
         self._obj = pandas_obj
         self._nrows = self._obj.shape[0]
-        self._SAMPLE_SIZE = SAMPLE_SIZE if self._nrows > 25000 else int(ceil(self._nrows / 25))
+        self._SAMPLE_SIZE = SAMPLE_SIZE if self._nrows > 25000 else int(ceil(self._nrows / 25.0))
 
         if npartitions is None:
             self._npartitions = cpu_count() * 2


### PR DESCRIPTION
If running in python 2, with sizes of less than 25, _SAMP_SIZE would evaluate to 0.

See also https://github.com/jmcarpenter2/swifter/issues/56 for a similar issue.