### PR TITLE
Use the current python executable in tests

### DIFF
--- a/swifter/swifter_tests.py
+++ b/swifter/swifter_tests.py
@@ -1,3 +1,4 @@
+import sys
 import unittest
 import subprocess
 import time
@@ -147,7 +148,7 @@ class TestSwifter(unittest.TestCase):
     def test_stdout_redirected(self):
         print_messages = subprocess.check_output(
             [
-                "python",
+                sys.executable,
                 "-c",
                 "import pandas as pd; import numpy as np; import swifter; "
                 + "df = pd.DataFrame({'x': np.random.normal(size=4)}); "


### PR DESCRIPTION
Currently it is hard-coded to use the default python executable rather than the one you are currently using to run swifter.  The default python may not have swifter installed for it.