### PR TITLE
Remove token from codecov

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -26,7 +26,7 @@ jobs:
           name: Codecov report
           command: |
             coverage report -i && coverage html -i
-            pip install codecov && codecov --required -t ${CODECOV_TOKEN} || (sleep 5 && codecov --required -t ${CODECOV_TOKEN}) || (sleep 5 && codecov --required -t ${CODECOV_TOKEN}) || (sleep 5 && codecov --required -t ${CODECOV_TOKEN}) || (sleep 5 && codecov --required -t ${CODECOV_TOKEN})
+            pip install codecov && codecov --required || (sleep 5 && codecov --required) || (sleep 5 && codecov --required) || (sleep 5 && codecov --required) || (sleep 5 && codecov --required)
       - store_artifacts:
           path: htmlcov
 

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,1 +1,5 @@
 include LICENSE
+
+graft assets
+graft docs
+graft examples


### PR DESCRIPTION
* By removing token from `codecov` this will allow for other contributors pull requests to pass CircleCI without error