### PR TITLE
Raise warning on duplicate indices

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -15,10 +15,6 @@ jobs:
           command: |
             pip install black && cd swifter && black -l 120 --check .
       - run:
-          name: Flake8 lint check
-          command: |
-            pip install flake8 && cd swifter && flake8 --max-line-length 120 .
-      - run:
           name: Unit tests
           command: |
             pip install pipenv && pipenv install && pipenv install coverage && pipenv run coverage run -m unittest swifter/swifter_tests.py

--- a/swifter/swifter.py
+++ b/swifter/swifter.py
@@ -11,7 +11,7 @@ from os import devnull
 from tqdm.auto import tqdm
 from .tqdm_dask_progressbar import TQDMDaskProgressBar
 
-from numba.errors import TypingError
+from numba.core.errors import TypingError
 
 warnings.filterwarnings("ignore", category=FutureWarning)
 

--- a/swifter/swifter.py
+++ b/swifter/swifter.py
@@ -13,6 +13,8 @@ from .tqdm_dask_progressbar import TQDMDaskProgressBar
 
 from numba.errors import TypingError
 
+warnings.filterwarnings("ignore", category=FutureWarning)
+
 SAMPLE_SIZE = 1000
 N_REPEATS = 3
 
@@ -40,6 +42,10 @@ class _SwifterObject:
         allow_dask_on_strings=False,
     ):
         self._obj = pandas_obj
+        if self._obj.index.duplicated().any():
+            warnings.warn(
+                "This pandas object has duplicate indices, and swifter may not be able to improve performance. Consider resetting the indices with `df.reset_index(drop=True)`."
+            )
         self._nrows = self._obj.shape[0]
         self._SAMPLE_SIZE = SAMPLE_SIZE if self._nrows > 25000 else int(ceil(self._nrows / 25))
 


### PR DESCRIPTION
## Context
* Per #106, swifter silently fails to improve performance when there are duplicate indices

## Added
* Warning to consider resetting indices when using swifter if there are duplicate indices

## Changed
* Filter the FutureWarning coming from tqdm/pandas