### PR TITLE
Fix vectorized form validation

### DIFF
--- a/swifter/swifter.py
+++ b/swifter/swifter.py
@@ -241,7 +241,7 @@ class SeriesAccessor(_SwifterObject):
             with suppress_stdout_stderr():
                 tmp_df = func(sample, *args, **kwds)
                 self._validate_apply(
-                    sample.apply(func, convert_dtype=convert_dtype, args=args, **kwds).equals(tmp_df),
+                    all(sample.apply(func, convert_dtype=convert_dtype, args=args, **kwds) == tmp_df),
                     error_message="Vectorized function sample doesn't match pandas apply sample.",
                 )
             return func(self._obj, *args, **kwds)
@@ -334,7 +334,7 @@ class DataFrameAccessor(_SwifterObject):
             with suppress_stdout_stderr():
                 tmp_df = func(sample, *args, **kwds)
                 self._validate_apply(
-                    sample.apply(func, axis=axis, raw=raw, result_type=result_type, args=args, **kwds).equals(tmp_df),
+                    all(sample.apply(func, axis=axis, raw=raw, result_type=result_type, args=args, **kwds) == tmp_df),
                     error_message="Vectorized function sample does not match pandas apply sample.",
                 )
             return func(self._obj, *args, **kwds)
@@ -430,7 +430,7 @@ class DataFrameAccessor(_SwifterObject):
             with suppress_stdout_stderr():
                 tmp_df = func(sample)
                 self._validate_apply(
-                    sample.apply(func).equals(tmp_df),
+                    all(sample.apply(func) == tmp_df),
                     error_message="Vectorized function sample does not match pandas apply sample.",
                 )
             return func(self._obj)

--- a/swifter/swifter.py
+++ b/swifter/swifter.py
@@ -1,5 +1,6 @@
 import timeit
 import warnings
+import numpy as np
 import pandas as pd
 
 from math import ceil
@@ -242,7 +243,7 @@ class SeriesAccessor(_SwifterObject):
                 tmp_df = func(sample, *args, **kwds)
                 sample_df = sample.apply(func, convert_dtype=convert_dtype, args=args, **kwds)
                 self._validate_apply(
-                    all(sample_df.values == tmp_df.values) & (sample_df.shape == tmp_df.shape),
+                    np.array_equal(sample_df, tmp_df) & (sample_df.shape == tmp_df.shape),
                     error_message="Vectorized function sample doesn't match pandas apply sample.",
                 )
             return func(self._obj, *args, **kwds)
@@ -336,7 +337,7 @@ class DataFrameAccessor(_SwifterObject):
             tmp_df = func(sample, *args, **kwds)
             sample_df = sample.apply(func, axis=axis, raw=raw, result_type=result_type, args=args, **kwds)
             self._validate_apply(
-                all(sample_df.values == tmp_df.values) & (sample_df.shape == tmp_df.shape),
+                np.array_equal(sample_df, tmp_df) & (sample_df.shape == tmp_df.shape),
                 error_message="Vectorized function sample does not match pandas apply sample.",
             )
             return func(self._obj, *args, **kwds)
@@ -433,7 +434,7 @@ class DataFrameAccessor(_SwifterObject):
                 tmp_df = func(sample)
                 sample_df = sample.applymap(func)
                 self._validate_apply(
-                    all(sample_df.values == tmp_df.values) & (sample_df.shape == tmp_df.shape),
+                    np.array_equal(sample_df, tmp_df) & (sample_df.shape == tmp_df.shape),
                     error_message="Vectorized function sample does not match pandas apply sample.",
                 )
             return func(self._obj)

--- a/swifter/swifter.py
+++ b/swifter/swifter.py
@@ -242,7 +242,7 @@ class SeriesAccessor(_SwifterObject):
                 tmp_df = func(sample, *args, **kwds)
                 sample_df = sample.apply(func, convert_dtype=convert_dtype, args=args, **kwds)
                 self._validate_apply(
-                    all(sample_df == tmp_df) & (sample_df.shape == tmp_df.shape),
+                    all(sample_df.values == tmp_df.values) & (sample_df.shape == tmp_df.shape),
                     error_message="Vectorized function sample doesn't match pandas apply sample.",
                 )
             return func(self._obj, *args, **kwds)
@@ -336,7 +336,7 @@ class DataFrameAccessor(_SwifterObject):
             tmp_df = func(sample, *args, **kwds)
             sample_df = sample.apply(func, axis=axis, raw=raw, result_type=result_type, args=args, **kwds)
             self._validate_apply(
-                all(sample_df == tmp_df) & (sample_df.shape == tmp_df.shape),
+                all(sample_df.values == tmp_df.values) & (sample_df.shape == tmp_df.shape),
                 error_message="Vectorized function sample does not match pandas apply sample.",
             )
             return func(self._obj, *args, **kwds)
@@ -433,7 +433,7 @@ class DataFrameAccessor(_SwifterObject):
                 tmp_df = func(sample)
                 sample_df = sample.applymap(func)
                 self._validate_apply(
-                    all(sample_df == tmp_df) & (sample_df.shape == tmp_df.shape),
+                    all(sample_df.values == tmp_df.values) & (sample_df.shape == tmp_df.shape),
                     error_message="Vectorized function sample does not match pandas apply sample.",
                 )
             return func(self._obj)

--- a/swifter/swifter.py
+++ b/swifter/swifter.py
@@ -333,13 +333,13 @@ class DataFrameAccessor(_SwifterObject):
         allow_dask_processing = True if self._allow_dask_on_strings else ("object" not in sample.dtypes.values)
 
         try:  # try to vectorize
-            # with suppress_stdout_stderr():
-            tmp_df = func(sample, *args, **kwds)
-            sample_df = sample.apply(func, axis=axis, raw=raw, result_type=result_type, args=args, **kwds)
-            self._validate_apply(
-                np.array_equal(sample_df, tmp_df) & (sample_df.shape == tmp_df.shape),
-                error_message="Vectorized function sample does not match pandas apply sample.",
-            )
+            with suppress_stdout_stderr():
+                tmp_df = func(sample, *args, **kwds)
+                sample_df = sample.apply(func, axis=axis, raw=raw, result_type=result_type, args=args, **kwds)
+                self._validate_apply(
+                    np.array_equal(sample_df, tmp_df) & (sample_df.shape == tmp_df.shape),
+                    error_message="Vectorized function sample does not match pandas apply sample.",
+                )
             return func(self._obj, *args, **kwds)
         except (
             AttributeError,

--- a/swifter/swifter.py
+++ b/swifter/swifter.py
@@ -240,8 +240,9 @@ class SeriesAccessor(_SwifterObject):
         try:  # try to vectorize
             with suppress_stdout_stderr():
                 tmp_df = func(sample, *args, **kwds)
+                sample_df = sample.apply(func, convert_dtype=convert_dtype, args=args, **kwds)
                 self._validate_apply(
-                    all(sample.apply(func, convert_dtype=convert_dtype, args=args, **kwds) == tmp_df),
+                    all(sample_df == tmp_df) & (sample_df.shape == tmp_df.shape),
                     error_message="Vectorized function sample doesn't match pandas apply sample.",
                 )
             return func(self._obj, *args, **kwds)
@@ -331,12 +332,13 @@ class DataFrameAccessor(_SwifterObject):
         allow_dask_processing = True if self._allow_dask_on_strings else ("object" not in sample.dtypes.values)
 
         try:  # try to vectorize
-            with suppress_stdout_stderr():
-                tmp_df = func(sample, *args, **kwds)
-                self._validate_apply(
-                    all(sample.apply(func, axis=axis, raw=raw, result_type=result_type, args=args, **kwds) == tmp_df),
-                    error_message="Vectorized function sample does not match pandas apply sample.",
-                )
+            # with suppress_stdout_stderr():
+            tmp_df = func(sample, *args, **kwds)
+            sample_df = sample.apply(func, axis=axis, raw=raw, result_type=result_type, args=args, **kwds)
+            self._validate_apply(
+                all(sample_df == tmp_df) & (sample_df.shape == tmp_df.shape),
+                error_message="Vectorized function sample does not match pandas apply sample.",
+            )
             return func(self._obj, *args, **kwds)
         except (
             AttributeError,
@@ -429,8 +431,9 @@ class DataFrameAccessor(_SwifterObject):
         try:  # try to vectorize
             with suppress_stdout_stderr():
                 tmp_df = func(sample)
+                sample_df = sample.applymap(func)
                 self._validate_apply(
-                    all(sample.apply(func) == tmp_df),
+                    all(sample_df == tmp_df) & (sample_df.shape == tmp_df.shape),
                     error_message="Vectorized function sample does not match pandas apply sample.",
                 )
             return func(self._obj)

--- a/swifter/swifter_tests.py
+++ b/swifter/swifter_tests.py
@@ -222,7 +222,7 @@ class TestSwifter(unittest.TestCase):
             self.assertLess(swifter_time, pd_time)
 
     def test_nonvectorized_math_apply_on_large_series(self):
-        df = pd.DataFrame({"x": np.random.normal(size=5_000_000)})
+        df = pd.DataFrame({"x": np.random.normal(size=10_000_000)})
         series = df["x"]
 
         start_pd = time.time()

--- a/swifter/swifter_tests.py
+++ b/swifter/swifter_tests.py
@@ -341,7 +341,7 @@ class TestSwifter(unittest.TestCase):
 
     def test_vectorized_math_apply_on_large_rolling_dataframe(self):
         df = pd.DataFrame(
-            {"x": np.arange(0, 1_500_000)}, index=pd.date_range("2019-01-1", "2020-01-1", periods=1_500_000)
+            {"x": np.arange(0, 2_000_000)}, index=pd.date_range("2019-01-1", "2020-01-1", periods=2_000_000)
         )
 
         start_pd = time.time()


### PR DESCRIPTION
## Context
* Vectorized apply form often returns numpy array, but we are attempting to compare the output of the vectorized sample as a dataframe

## Changed
* Compare vectorized sample with pd sample apply using `all(a.values == b.values) & (a.shape == b.shape)` rather than `a.equals(b)`