### PR TITLE
Add Modin as a dependency of Swifter.

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -18,6 +18,7 @@ tqdm = ">=4.33.0"
 ipywidgets = ">=7.0.0"
 bleach = ">=3.1.1"
 parso = ">0.4.0"
+modin = {extras = ["ray"],version = ">=0.7.3"}
 
 [requires]
 python_version = "3.7"

--- a/setup.py
+++ b/setup.py
@@ -10,6 +10,6 @@ setup(
     url="https://github.com/jmcarpenter2/swifter",  # use the URL to the github repo
     download_url="https://github.com/jmcarpenter2/swifter/archive/0.305.tar.gz",
     keywords=["pandas", "dask", "apply", "function", "parallelize", "vectorize"],
-    install_requires=["pandas>=0.23.0", "psutil>=5.6.6", "dask[complete]>=0.19.0", "tqdm>=4.33.0", "ipywidgets>=7.0.0", "parso>0.4.0", "bleach>=3.1.1"],
+    install_requires=["pandas>=0.23.0", "psutil>=5.6.6", "dask[complete]>=0.19.0", "tqdm>=4.33.0", "ipywidgets>=7.0.0", "parso>0.4.0", "bleach>=3.1.1", "modin[ray]>=0.7.3"],
     classifiers=[],
 )


### PR DESCRIPTION
Progress toward #93. This is a start toward using Modin under Swifter to accelerate `apply`.

Some considerations:
- Ray has become available on Windows as of the most recent release. The version Modin 0.7.3 relies on is not tied to that release (though the next release will be).
- The next Modin release is scheduled for the end of July
