### PR TITLE
Reduce compute overhead

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,8 @@ import swifter
 import modin.pandas as pd
 import swifter
 ```
+NOTE: if you import swifter before modin, you will have to additionally register modin: `swifter.register_modin()`
+
 
 ## Easy to use
 ```python
@@ -71,6 +73,8 @@ Check out the [examples notebook](examples/swifter_apply_examples.ipynb), along 
 
 2. Please upgrade your version of pandas, as the pandas extension api used in this module is a recent addition to pandas.
 
-3. Do not use swifter to apply a function that modifies external variables. Under the hood, swifter does sample applies to optimize performance. These sample applies will modify the external variable in addition to the final apply. Thus, you will end up with an erroneously modified external variable.
+3. Import modin before importing swifter, if you wish to use modin with swifter. Otherwise, use `swifter.register_modin()` to access it.
 
-4. It is advised to disable the progress bar if calling swifter from a forked process as the progress bar may get confused between various multiprocessing modules. 
+4. Do not use swifter to apply a function that modifies external variables. Under the hood, swifter does sample applies to optimize performance. These sample applies will modify the external variable in addition to the final apply. Thus, you will end up with an erroneously modified external variable.
+
+5. It is advised to disable the progress bar if calling swifter from a forked process as the progress bar may get confused between various multiprocessing modules.

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Version 1.0.1 -- 2020-07-27
+* Reduce resources consumed by swifter by only importing modin/ray when necessary.
+* Added `swifter.register_modin()` function, which gives access to `modin.DataFrame.swifter.apply(...)`, but is only required if modin is imported after swifter. If you import modin before swifter, this is not necessary.
+
 ## Version 1.0.0 -- 2020-07-27
 Two major enhancements are included in this release, both involving the use of modin in swifter. Special thanks to Devin Petersohn for the collaboration.
 

--- a/docs/documentation.md
+++ b/docs/documentation.md
@@ -210,3 +210,8 @@ For example, let's say we have a pandas dataframe df. The following will allow D
 ```python
 df.swifter.allow_dask_on_strings().apply(lambda x: x+1)
 ```
+
+## 12. `swifter.register_modin()`
+
+This gives access to `modin.DataFrame.swifter.apply(...)` and `modin.Series.swifter.apply(...)`. This registers modin dataframes and series with swifter as accessors.
+* NOTE: This is only necessary if you import swifter BEFORE modin. If you import modin before swifter you do not need to execute this method.

--- a/setup.py
+++ b/setup.py
@@ -3,12 +3,12 @@ from setuptools import find_packages, setup, Extension
 setup(
     name="swifter",
     packages=["swifter"],  # this must be the same as the name above
-    version="1.0.0",
+    version="1.0.1",
     description="A package which efficiently applies any function to a pandas dataframe or series in the fastest available manner",
     author="Jason Carpenter",
     author_email="jcarpenter@manifold.ai",
     url="https://github.com/jmcarpenter2/swifter",  # use the URL to the github repo
-    download_url="https://github.com/jmcarpenter2/swifter/archive/1.0.0.tar.gz",
+    download_url="https://github.com/jmcarpenter2/swifter/archive/1.0.1.tar.gz",
     keywords=["pandas", "dask", "apply", "function", "parallelize", "vectorize"],
     install_requires=["pandas>=0.23.0", "psutil>=5.6.6", "dask[complete]>=0.19.0", "tqdm>=4.33.0", "ipywidgets>=7.0.0", "parso>0.4.0", "bleach>=3.1.1", "modin[ray]>=0.7.4", "pickle5>=0.0.11"],
     classifiers=[],

--- a/swifter/__init__.py
+++ b/swifter/__init__.py
@@ -1,7 +1,12 @@
 # flake8: noqa
 import sys
+import warnings
+from logging import config
 from .swifter import SeriesAccessor, DataFrameAccessor
 from .parallel_accessor import register_parallel_dataframe_accessor, register_parallel_series_accessor, register_modin
+
+config.dictConfig({"version": 1, "disable_existing_loggers": True})
+warnings.filterwarnings("ignore", category=FutureWarning)
 
 if "modin.pandas" in sys.modules:
     register_modin()

--- a/swifter/__init__.py
+++ b/swifter/__init__.py
@@ -1,12 +1,16 @@
 # flake8: noqa
-
+import sys
 from .swifter import SeriesAccessor, DataFrameAccessor
-from .parallel_accessor import register_parallel_dataframe_accessor, register_parallel_series_accessor
+from .parallel_accessor import register_parallel_dataframe_accessor, register_parallel_series_accessor, register_modin
+
+if "modin.pandas" in sys.modules:
+    register_modin()
 
 __all__ = [
     "SeriesAccessor",
     "DataFrameAccessor",
     "register_parallel_dataframe_accessor",
     "register_parallel_series_accessor",
+    "register_modin",
 ]
-__version__ = "1.0.0"
+__version__ = "1.0.1"

--- a/swifter/parallel_accessor.py
+++ b/swifter/parallel_accessor.py
@@ -81,3 +81,13 @@ def register_parallel_dataframe_accessor(dataframe_to_register):
         self.swifter = ParallelDataFrameAccessor(self)
 
     dataframe_to_register.__init__ = new_init
+
+
+def register_modin():
+    """
+    Register modin's series/dataframe as parallel accessors
+    """
+    from modin.pandas import Series, DataFrame
+
+    register_parallel_series_accessor(Series)
+    register_parallel_dataframe_accessor(DataFrame)

--- a/swifter/swifter.py
+++ b/swifter/swifter.py
@@ -6,7 +6,6 @@ import pandas as pd
 
 from abc import abstractmethod
 from math import ceil
-from logging import config
 from dask import dataframe as dd
 
 from tqdm.auto import tqdm
@@ -19,10 +18,6 @@ from .base import (
     SAMPLE_SIZE,
     N_REPEATS,
 )
-from .parallel_accessor import register_modin
-
-config.dictConfig({"version": 1, "disable_existing_loggers": True})
-warnings.filterwarnings("ignore", category=FutureWarning)
 
 
 class _SwifterObject(_SwifterBaseObject):

--- a/swifter/swifter.py
+++ b/swifter/swifter.py
@@ -1,3 +1,4 @@
+import sys
 import timeit
 import warnings
 import numpy as np
@@ -18,14 +19,10 @@ from .base import (
     SAMPLE_SIZE,
     N_REPEATS,
 )
-from .parallel_accessor import register_parallel_series_accessor, register_parallel_dataframe_accessor
+from .parallel_accessor import register_modin
 
 config.dictConfig({"version": 1, "disable_existing_loggers": True})
 warnings.filterwarnings("ignore", category=FutureWarning)
-import modin.pandas as md
-
-register_parallel_series_accessor(md.Series)
-register_parallel_dataframe_accessor(md.DataFrame)
 
 
 class _SwifterObject(_SwifterBaseObject):
@@ -256,6 +253,8 @@ class DataFrameAccessor(_SwifterObject):
         sample = self._obj.iloc[: self._npartitions * 2, :]
         try:
             with suppress_stdout_stderr():
+                import modin.pandas as md
+
                 sample_df = sample.apply(func, axis=axis, raw=raw, result_type=result_type, args=args, **kwds)
                 # check that the modin apply matches the pandas APPLY
                 tmp_df = (


### PR DESCRIPTION
## Context
* Swifter currently incidentally launches a ray cluster upon `import swifter`. We don't want to be bringing about extra compute overhead for users.

## Changes
* Only import modin/ray as needed to execute code. This does mean that if someone does the following they will need to call an additional method to access swifter with modin dataframes.
```python
import swifter
import modin.pandas as pd
swifter.register_modin()  # only necessary if swifter is imported first
```