### PR TITLE
Authenticate docker image pulls

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,6 +8,9 @@ jobs:
     working_directory: ~/repo
     docker:
       - image: python:3.7
+        auth:
+          username: $DOCKERHUB_USERNAME
+          password: $DOCKERHUB_PASSWORD
 
     steps:
       - checkout

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,7 +1,8 @@
 # Changelog
 
-## Version 1.0.6 -- 2020-10-11
+## Version 1.0.7 -- 2020-10-11
 * Sample applies now suppress logging in addition to stdout and stderr
+* Allow new kwargs `offset` and `origin` for pandas df.resample
 
 ## Version 1.0.6 -- 2020-09-19
 * Fix warnings introduced in 1.0.5 to appropriate warn when using an apply function


### PR DESCRIPTION
## Context
* Dockerhub now rate limits image pulls from anonymous users

## Changed
* Authenticate docker image pulls with dockerhub login information