### PR TITLE
Make modin optional and allow user to decide which modin version to use

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,8 @@ Check out the [examples notebook](examples/swifter_apply_examples.ipynb), along 
 ```
 $ pip install -U pandas # upgrade pandas
 $ pip install swifter # first time installation
+$ pip install swifter[ray] # first time installation including modin[ray]
+$ pip install swifter[dask] # first time installation including modin[dask]
 
 $ pip install -U swifter # upgrade to latest version if already installed
 ```

--- a/setup.py
+++ b/setup.py
@@ -10,6 +10,10 @@ setup(
     url="https://github.com/jmcarpenter2/swifter",  # use the URL to the github repo
     download_url="https://github.com/jmcarpenter2/swifter/archive/1.0.7.tar.gz",
     keywords=["pandas", "dask", "apply", "function", "parallelize", "vectorize"],
-    install_requires=["pandas>=1.0.0", "psutil>=5.6.6", "dask[dataframe]>=2.10.0", "tqdm>=4.33.0", "ipywidgets>=7.0.0" "cloudpickle>=0.2.2", "parso>0.4.0", "bleach>=3.1.1", "modin[ray]>=0.8.1.1"],
+    install_requires=["pandas>=1.0.0", "psutil>=5.6.6", "dask[dataframe]>=2.10.0", "tqdm>=4.33.0", "ipywidgets>=7.0.0" "cloudpickle>=0.2.2", "parso>0.4.0", "bleach>=3.1.1"],
+    extras_require={
+        "ray": ["modin[ray]>=0.8.1.1"],
+        "dask": ["modin[dask]>=0.8.1.1"]
+    },
     classifiers=[],
 )


### PR DESCRIPTION
#150 #147 #146
Allows users to install like:
`pip install swifter`
`pip install swifter[ray]`
or
`pip install swifter[dask]`
for no modin, modin[ray] and modin[dask] respectively.
See setuptools docs here:  [https://setuptools.readthedocs.io/en/latest/userguide/dependency_management.html#optional-dependencies](https://setuptools.readthedocs.io/en/latest/userguide/dependency_management.html#optional-dependencies)