### PR TITLE
Add global configuration support

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1,0 +1,49 @@
+# Configuration
+
+You can configure `swifter` on a global level, which impacts all instances, or
+on a local (inline) level, which impacts only that instance of
+`.swifter.apply`.
+
+## Global configuration
+
+You can set global configuration options by calling the corresponding method on
+the main import `swifter`.
+
+```python
+import swifter
+
+swifter.set_dask_threshold(dask_threshold=1)
+swifter.set_dask_scheduler(scheduler="processes")
+swifter.progress_bar(enable=True, desc=None)
+swifter.allow_dask_on_strings(enable=True)
+
+# Global configuration is stored in the following dictionary
+print(swifter.config)
+# => {
+#        "npartitions": None,
+#        "dask_threshold": 1,
+#        "scheduler": "processes",
+#        "progress_bar": True,
+#        "progress_bar_desc": None,
+#        "allow_dask_on_strings": False,
+#    }
+```
+
+## Inline configuration
+
+You can set local configuration options for a specific `.swifter.apply` by
+calling the corresponding method on the accessor.
+
+```python
+import pandas as pd
+import swifter
+
+series = pd.Series(np.arange(1000))
+
+def square(x): return x ** 2
+
+series.swifter.set_dask_threshold(dask_threshold=1).apply(square)
+series.swifter.set_dask_scheduler(scheduler="processes").apply(square)
+series.swifter.progress_bar(enable=True, desc=None).apply(square)
+series.swifter.allow_dask_on_strings(enable=True).apply(square)
+```

--- a/swifter/__init__.py
+++ b/swifter/__init__.py
@@ -1,9 +1,21 @@
 # flake8: noqa
 import sys
 import warnings
-from logging import config
+
+from logging import config as logging_config
 from .swifter import SeriesAccessor, DataFrameAccessor
-from .parallel_accessor import register_parallel_dataframe_accessor, register_parallel_series_accessor, register_modin
+from .parallel_accessor import (
+    register_parallel_dataframe_accessor,
+    register_parallel_series_accessor,
+    register_modin,
+)
+from .config import (
+    config,
+    set_dask_threshold,
+    set_dask_scheduler,
+    progress_bar,
+    allow_dask_on_strings,
+)
 
 warnings.filterwarnings("ignore", category=FutureWarning)
 
@@ -16,5 +28,10 @@ __all__ = [
     "register_parallel_dataframe_accessor",
     "register_parallel_series_accessor",
     "register_modin",
+    "config",
+    "set_dask_threshold",
+    "set_dask_scheduler",
+    "progress_bar",
+    "allow_dask_on_strings",
 ]
 __version__ = "1.0.9"

--- a/swifter/config.py
+++ b/swifter/config.py
@@ -1,0 +1,41 @@
+config = {
+    "npartitions": None,
+    "dask_threshold": 1,
+    "scheduler": "processes",
+    "progress_bar": True,
+    "progress_bar_desc": None,
+    "allow_dask_on_strings": False,
+}
+
+
+def set_dask_threshold(dask_threshold=1):
+    """
+    Set the threshold (seconds) for maximum allowed estimated duration of
+    pandas apply before switching to dask.
+    """
+    config["dask_threshold"] = dask_threshold
+
+
+def set_dask_scheduler(scheduler="processes"):
+    """
+    Set the dask scheduler.
+
+    :param scheduler: String, ["threads", "processes"]
+    """
+    config["scheduler"] = scheduler
+
+
+def progress_bar(enable=True, desc=None):
+    """
+    Turn on/off the progress bar, and optionally add a custom description
+    """
+    config["progress_bar"] = enable
+    config["progress_bar_desc"] = desc
+
+
+def allow_dask_on_strings(enable=True):
+    """
+    Override the string processing default, which is to not use dask if a
+    string is contained in the pandas object.
+    """
+    config["allow_dask_on_strings"] = enable


### PR DESCRIPTION
hey there,

i wanted to disable the progress bar globally (as described in #153), so i've added some basic support to be able to globally configure swifter using the same method (names) you use to configure an individual accessor instance.

here's what i have(n't) done:
- [x] add `config` object in `swifter/config.py`
- [x] add global configuration methods on the main import, e.g. `import swifter; swifter.progress_bar(False)`
- [x] add very basic configuration docs outline (you might want to consider merging the configuration part in `documentation.md` into `configuration.md`).
- [ ] add tests.

great work on the package, by the way, it's a joy to use!