### PR TITLE
Add force parallel functionality

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## Version 1.1.5 -- 2022-07-06
+## Version 1.2.0 -- 2022-07-06
 * Enable users to `force_parallel` which immediately forces swifter to jump to using dask apply. This enables a simple interface for parallel processing, but disables swifter's algorithm to determine the fastest apply solution possible.
 
 ## Version 1.1.4 -- 2022-06-29

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## Version 1.1.5 -- 2022-07-06
+* Enable users to `force_parallel` which immediately forces swifter to jump to using dask apply. This enables a simple interface for parallel processing, but disables swifter's algorithm to determine the fastest apply solution possible.
+
 ## Version 1.1.4 -- 2022-06-29
 * Enable users to leverage `set_defaults` functionality so they don't have to keep invoking individual settings on a per swifter invocation basis
 

--- a/docs/documentation.md
+++ b/docs/documentation.md
@@ -45,6 +45,9 @@ set_defaults(
 `allow_dask_on_strings` : Boolean. Allows user to enable dask parallel processing on string data
     Default: `False`
 
+`force_parallel` : Boolean. Allows user to override swifter algorithm and jump straight to using dask processing
+    Default: `False`
+
 
 
 ## 2. `pandas.Series.swifter.apply` OR `modin.pandas.Series.swifter.apply`
@@ -226,7 +229,19 @@ For example, let's say we have a pandas dataframe df. The following will allow D
 df.swifter.allow_dask_on_strings().apply(lambda x: x+1)
 ```
 
-## 12. `swifter.register_modin()`
+## 11. `pandas.DataFrame.swifter.force_parallel(enable=True).apply`
+
+This flag allows the user to specify to override swifter's default functionality to run try vectorization, sample applies, and determine the fastest apply possible. Instead it forces swifter to use dask.
+```python
+def pandas.DataFrame.swifter.force_parallel(enable=True)
+```
+
+For example, let's say we have a pandas dataframe df. The following will force Dask to process the dataframe.
+```python
+df.swifter.force_parallel().apply(lambda x: x+1)
+```
+
+## 13. `swifter.register_modin()`
 
 This gives access to `modin.DataFrame.swifter.apply(...)` and `modin.Series.swifter.apply(...)`. This registers modin dataframes and series with swifter as accessors.
 * NOTE: This is only necessary if you import swifter BEFORE modin. If you import modin before swifter you do not need to execute this method.

--- a/examples/swifter_apply_examples.ipynb
+++ b/examples/swifter_apply_examples.ipynb
@@ -34,6 +34,27 @@
   {
    "cell_type": "code",
    "execution_count": 2,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "bug.ipynb\r\n",
+      "modin_dataframe_swifter_performance_benchmark.ipynb\r\n",
+      "swifter_apply_examples.ipynb\r\n",
+      "swifter_groupby_example.ipynb\r\n",
+      "swifter_speed_comparison.ipynb\r\n"
+     ]
+    }
+   ],
+   "source": [
+    "!ls"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
    "metadata": {
     "ExecuteTime": {
      "end_time": "2020-09-19T20:42:35.334991Z",
@@ -42,12 +63,12 @@
    },
    "outputs": [],
    "source": [
-    "trips = pd.read_csv('trip.csv')"
+    "trips = pd.read_csv('../data/trip.csv')"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": null,
    "metadata": {
     "ExecuteTime": {
      "end_time": "2020-09-19T20:58:23.121034Z",
@@ -56,107 +77,19 @@
    },
    "outputs": [],
    "source": [
-    "data = pd.read_csv('status.csv')"
+    "data = pd.read_csv(\"../data/status.csv\")"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": null,
    "metadata": {
     "ExecuteTime": {
      "end_time": "2020-09-19T20:58:23.194239Z",
      "start_time": "2020-09-19T20:58:23.131557Z"
     }
    },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "(71984434, 4)\n"
-     ]
-    },
-    {
-     "data": {
-      "text/html": [
-       "<div>\n",
-       "<style scoped>\n",
-       "    .dataframe tbody tr th:only-of-type {\n",
-       "        vertical-align: middle;\n",
-       "    }\n",
-       "\n",
-       "    .dataframe tbody tr th {\n",
-       "        vertical-align: top;\n",
-       "    }\n",
-       "\n",
-       "    .dataframe thead th {\n",
-       "        text-align: right;\n",
-       "    }\n",
-       "</style>\n",
-       "<table border=\"1\" class=\"dataframe\">\n",
-       "  <thead>\n",
-       "    <tr style=\"text-align: right;\">\n",
-       "      <th></th>\n",
-       "      <th>station_id</th>\n",
-       "      <th>bikes_available</th>\n",
-       "      <th>docks_available</th>\n",
-       "      <th>time</th>\n",
-       "    </tr>\n",
-       "  </thead>\n",
-       "  <tbody>\n",
-       "    <tr>\n",
-       "      <th>0</th>\n",
-       "      <td>2</td>\n",
-       "      <td>2</td>\n",
-       "      <td>25</td>\n",
-       "      <td>2013/08/29 12:06:01</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>1</th>\n",
-       "      <td>2</td>\n",
-       "      <td>2</td>\n",
-       "      <td>25</td>\n",
-       "      <td>2013/08/29 12:07:01</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>2</th>\n",
-       "      <td>2</td>\n",
-       "      <td>2</td>\n",
-       "      <td>25</td>\n",
-       "      <td>2013/08/29 12:08:01</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>3</th>\n",
-       "      <td>2</td>\n",
-       "      <td>2</td>\n",
-       "      <td>25</td>\n",
-       "      <td>2013/08/29 12:09:01</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>4</th>\n",
-       "      <td>2</td>\n",
-       "      <td>2</td>\n",
-       "      <td>25</td>\n",
-       "      <td>2013/08/29 12:10:01</td>\n",
-       "    </tr>\n",
-       "  </tbody>\n",
-       "</table>\n",
-       "</div>"
-      ],
-      "text/plain": [
-       "   station_id  bikes_available  docks_available                 time\n",
-       "0           2                2               25  2013/08/29 12:06:01\n",
-       "1           2                2               25  2013/08/29 12:07:01\n",
-       "2           2                2               25  2013/08/29 12:08:01\n",
-       "3           2                2               25  2013/08/29 12:09:01\n",
-       "4           2                2               25  2013/08/29 12:10:01"
-      ]
-     },
-     "execution_count": 3,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "print(data.shape)\n",
     "data.head()"
@@ -188,6 +121,15 @@
   },
   {
    "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "max_x = np.max(data['bikes_available'])"
+   ]
+  },
+  {
+   "cell_type": "code",
    "execution_count": 8,
    "metadata": {
     "scrolled": true
@@ -203,7 +145,7 @@
     }
    ],
    "source": [
-    "%time data['bike_prop'] = data['bikes_available'].swifter.apply(bikes_proportion, max_x=np.max(data['bikes_available']))"
+    "%time data['bike_prop'] = data['bikes_available'].swifter.apply(bikes_proportion, max_x=max_x)"
    ]
   },
   {
@@ -1392,7 +1334,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
   },
@@ -1406,7 +1348,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.6"
+   "version": "3.9.13"
   },
   "toc": {
    "base_numbering": 1,

--- a/setup.py
+++ b/setup.py
@@ -3,12 +3,12 @@ from setuptools import setup
 setup(
     name="swifter",
     packages=["swifter"],  # this must be the same as the name above
-    version="1.1.4",
+    version="1.2.0",
     description="A package which efficiently applies any function to a pandas dataframe or series in the fastest available manner",
     author="Jason Carpenter",
     author_email="jcarpenter@manifold.ai",
     url="https://github.com/jmcarpenter2/swifter",  # use the URL to the github repo
-    download_url=f"https://github.com/jmcarpenter2/swifter/archive/1.1.4.tar.gz",
+    download_url=f"https://github.com/jmcarpenter2/swifter/archive/1.2.0.tar.gz",
     keywords=["pandas", "dask", "apply", "function", "parallelize", "vectorize"],
     install_requires=[
         "pandas>=1.0.0",

--- a/swifter/__init__.py
+++ b/swifter/__init__.py
@@ -22,4 +22,4 @@ __all__ = [
     "register_parallel_series_accessor",
     "register_modin",
 ]
-__version__ = "1.1.4"
+__version__ = "1.2.0"

--- a/swifter/base.py
+++ b/swifter/base.py
@@ -41,7 +41,6 @@ class _SwifterBaseObject:
         self._nrows = self._obj.shape[0]
         self._SAMPLE_SIZE = SAMPLE_SIZE if self._nrows > (25 * SAMPLE_SIZE) else int(ceil(self._nrows / 25))
         self._SAMPLE_INDEX = sorted(np.random.choice(range(self._nrows), size=self._SAMPLE_SIZE, replace=False))
-        self._ray_memory = None
         self.set_npartitions(npartitions=npartitions)
 
     @staticmethod

--- a/swifter/parallel_accessor.py
+++ b/swifter/parallel_accessor.py
@@ -35,6 +35,15 @@ class _SwifterParallelBaseObject(_SwifterBaseObject):
         warnings.warn("Parallel Accessor does not use Dask.")
         return self
 
+    def force_parallel(self, enable=True):
+        """
+        Force swifter to use dask parallel processing, without attempting any
+        vectorized solution or estimating pandas apply duration to determine
+        what will be the fastest approach
+        """
+        warnings.warn("Parallel Accessor does not use Dask.")
+        return self
+
     def rolling(
         self,
         window,


### PR DESCRIPTION
Resolves issues #149 by enabling `force_parallel` option

This capability is great for users who just want an easy way to use parallel processing on a pandas dataframe, without getting involved with swifter's algorithm to choose the fastest apply approach for you.