### PR TITLE
v1.3.3: Allow Groupby Index

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## Version 1.3.3 -- 2022-07-28
+* Enable users to pass in `df.index` as the by parameter for the df.swifter.groupby(by).apply(func) command
+
 ## Version 1.3.2 -- 2022-07-23
 * Enable users to `df.swifter.groupby.apply`, which requires a new package (ray) that now available as an extra_requires.
 * To use groupby apply, install swifter as `pip install -U swifter[groupby]`

--- a/setup.py
+++ b/setup.py
@@ -3,12 +3,12 @@ from setuptools import setup
 setup(
     name="swifter",
     packages=["swifter"],  # this must be the same as the name above
-    version="1.3.2",
+    version="1.3.3",
     description="A package which efficiently applies any function to a pandas dataframe or series in the fastest available manner",
     author="Jason Carpenter",
     author_email="jcarpenter@manifold.ai",
     url="https://github.com/jmcarpenter2/swifter",  # use the URL to the github repo
-    download_url=f"https://github.com/jmcarpenter2/swifter/archive/1.3.2.tar.gz",
+    download_url=f"https://github.com/jmcarpenter2/swifter/archive/1.3.3.tar.gz",
     keywords=["pandas", "dask", "apply", "function", "parallelize", "vectorize"],
     install_requires=[
         "pandas>=1.0.0",

--- a/swifter/__init__.py
+++ b/swifter/__init__.py
@@ -22,4 +22,4 @@ __all__ = [
     "register_parallel_series_accessor",
     "register_modin",
 ]
-__version__ = "1.3.2"
+__version__ = "1.3.3"

--- a/swifter/swifter_tests.py
+++ b/swifter/swifter_tests.py
@@ -760,6 +760,19 @@ class TestPandasDataFrame(TestSwifter):
         swifter_val = df.swifter.groupby("g").apply(numeric_func)
         self.assertSeriesEqual(pd_val, swifter_val, "Swifter output does not equal Pandas output")  # equality test
 
+    def test_vectorized_math_groupby_apply_on_large_dataframe_index(self):
+        LOG.info("test_vectorized_math_groupby_apply_on_large_dataframe_index")
+        df = pd.DataFrame(
+            {
+                "x": np.random.normal(size=500000),
+                "y": np.random.uniform(size=500000),
+            },
+            index=np.random.choice(np.arange(50000), size=500000),
+        )
+        pd_val = df.groupby(df.index).apply(numeric_func)
+        swifter_val = df.swifter.groupby(df.index).apply(numeric_func)
+        self.assertSeriesEqual(pd_val, swifter_val, "Swifter output does not equal Pandas output")  # equality test
+
     def test_vectorized_force_parallel_math_groupby_apply_on_large_dataframe(self):
         LOG.info("test_vectorized_force_parallel_math_groupby_apply_on_large_dataframe")
         df = pd.DataFrame(


### PR DESCRIPTION
Resolves bug I noticed about passing in `df.index` to `by` argument of `groupby`