### PR TITLE
v1.3.4: Groupby Apply Enhancements

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## Version 1.3.4 -- 2022-08-16
+* Enable indexing after a groupby, e.g. `df.swifter.groupby(by)[key].apply(func)`
+* Improve groupby apply progress bar
+  - Previously, the groupby apply progress bar only appeared after the data was distributed across the cores.
+  - Now, the groupby apply progress bar appears before the data is distributed for a more realistic reflection of how long it took
+* Additional groupby apply code refactoring and optimizations, including removing the mutability of the data within `ray`
+
 ## Version 1.3.3 -- 2022-07-28
 * Enable users to pass in `df.index` as the by parameter for the df.swifter.groupby(by).apply(func) command
 

--- a/setup.py
+++ b/setup.py
@@ -3,12 +3,12 @@ from setuptools import setup
 setup(
     name="swifter",
     packages=["swifter"],  # this must be the same as the name above
-    version="1.3.3",
+    version="1.3.4",
     description="A package which efficiently applies any function to a pandas dataframe or series in the fastest available manner",
     author="Jason Carpenter",
     author_email="jcarpenter@manifold.ai",
     url="https://github.com/jmcarpenter2/swifter",  # use the URL to the github repo
-    download_url=f"https://github.com/jmcarpenter2/swifter/archive/1.3.3.tar.gz",
+    download_url=f"https://github.com/jmcarpenter2/swifter/archive/1.3.4.tar.gz",
     keywords=["pandas", "dask", "apply", "function", "parallelize", "vectorize"],
     install_requires=[
         "pandas>=1.0.0",

--- a/swifter/__init__.py
+++ b/swifter/__init__.py
@@ -22,4 +22,4 @@ __all__ = [
     "register_parallel_series_accessor",
     "register_modin",
 ]
-__version__ = "1.3.3"
+__version__ = "1.3.4"

--- a/swifter/swifter_tests.py
+++ b/swifter/swifter_tests.py
@@ -12,6 +12,7 @@ import numpy.testing as npt
 import pandas as pd
 import swifter
 
+from .swifter import GROUPBY_MAX_ROWS_PANDAS_DEFAULT
 from tqdm.auto import tqdm
 
 
@@ -482,6 +483,20 @@ class TestPandasDataFrame(TestSwifter):
         pd_val = df.groupby("x").apply(math_vec_square)
         swifter_val = df.swifter.groupby("x").apply(math_vec_square)
         self.assertEqual(pd_val, swifter_val)  # equality test
+
+    def test_groupby_index_apply(self):
+        LOG.info("test_groupby_index_apply")
+        SIZE = GROUPBY_MAX_ROWS_PANDAS_DEFAULT * 2
+        df = pd.DataFrame(
+            {
+                "x": np.random.normal(size=SIZE),
+                "y": np.random.uniform(size=SIZE),
+                "g": np.random.choice(np.arange(100), size=SIZE),
+            }
+        )
+        pd_val = df.groupby("g")["x"].apply(lambda x: x.std())
+        swifter_val = df.swifter.groupby("g")["x"].apply(lambda x: x.std())
+        self.assertEqual(pd_val, swifter_val)
 
     def test_nonvectorized_math_apply_on_small_dataframe(self):
         LOG.info("test_nonvectorized_math_apply_on_small_dataframe")


### PR DESCRIPTION
* Enable indexing after a groupby, e.g. `df.swifter.groupby(by)[key].apply(func)`
* Improve groupby apply progress bar
  - Previously, the groupby apply progress bar only appeared after the data was distributed across the cores.
  - Now, the groupby apply progress bar appears before the data is distributed for a more realistic reflection of how long it took
* Additional groupby apply code refactoring and optimizations, including removing the mutability of the data within `ray`