### PR TITLE
Add secondary fallback for SeriesAccessor + code refactoring

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -18,6 +18,7 @@ jobs:
       - run:
           name: Install requirements
           command: |
+            pip install --upgrade pip
             pip install -r docker/requirements-dev.txt
       - run:
           name: Black lint check
@@ -47,7 +48,8 @@ jobs:
       - run:
           name: Install requirements
           command: |
-            pip install -r docker/requirements-dev.txt
+            pip install --upgrade pip
+            pip install -r docker/requirements-windows.txt
           shell: bash.exe
       - run:
           name: Unit tests

--- a/docker/Dockerfile-dev
+++ b/docker/Dockerfile-dev
@@ -1,6 +1,8 @@
 FROM python:3.9
+ADD requirements-windows.txt /build/requirements-windows.txt
 ADD requirements-dev.txt /build/requirements-dev.txt
 WORKDIR /build/
+RUN pip install --upgrade pip
 RUN pip install -r requirements-dev.txt
 WORKDIR /mnt/
 ENV PYTHONPATH "${PYTHONPATH}:/mnt"

--- a/docker/requirements-dev.txt
+++ b/docker/requirements-dev.txt
@@ -1,18 +1,2 @@
-pandas>=1.0.0
-psutil>=5.6.6
+-r requirements-windows.txt
 ray>=1.0.0
-dask[dataframe]>=2.10.0
-modin[dask]>=0.8.1.1
-tqdm>=4.33.0
-ipywidgets>=7.0.0
-cloudpickle>=0.2.2
-parso>0.4.0
-bleach>=3.1.1
-black==22.3.0
-flake8==3.7.7
-perfplot==0.7.3
-pytest==6.2.2
-jupyterlab==3.6.2
-coverage
-codecov
-nose

--- a/docker/requirements-windows.txt
+++ b/docker/requirements-windows.txt
@@ -1,0 +1,17 @@
+pandas>=1.0.0
+psutil>=5.6.6
+dask[dataframe]>=2.10.0
+modin[dask]>=0.8.1.1
+tqdm>=4.33.0
+ipywidgets>=7.0.0
+cloudpickle>=0.2.2
+parso>0.4.0
+bleach>=3.1.1
+black==22.3.0
+flake8==3.7.7
+perfplot==0.7.3
+pytest==6.2.2
+jupyterlab==3.6.2
+coverage
+codecov
+nose

--- a/swifter/swifter_tests.py
+++ b/swifter/swifter_tests.py
@@ -13,7 +13,8 @@ import numpy.testing as npt
 import pandas as pd
 import swifter
 
-from .swifter import GROUPBY_MAX_ROWS_PANDAS_DEFAULT
+from .swifter import RAY_INSTALLED, GROUPBY_MAX_ROWS_PANDAS_DEFAULT
+
 from tqdm.auto import tqdm
 
 WINDOWS_CI = "windows" in os.environ.get("CIRCLE_JOB", "")
@@ -73,6 +74,14 @@ def run_if_modin_installed(cls):
     if importlib.util.find_spec("modin") is not None:
         return cls
     else:  # if modin isnt installed just skip the test(s)
+        return True
+
+
+def run_if_ray_installed(func):
+    # if ray is installed, run the test/test suite
+    if RAY_INSTALLED:
+        return func
+    else:  # if ray isnt installed just skip the test(s)
         return True
 
 
@@ -486,6 +495,7 @@ class TestPandasDataFrame(TestSwifter):
         swifter_val = df.swifter.applymap(math_vec_square)
         self.assertEqual(pd_val, swifter_val)  # equality test
 
+    @run_if_ray_installed
     def test_groupby_apply_on_empty_dataframe(self):
         LOG.info("test_groupby_apply_on_empty_dataframe")
         df = pd.DataFrame(columns=["x", "y"])
@@ -493,6 +503,7 @@ class TestPandasDataFrame(TestSwifter):
         swifter_val = df.swifter.groupby("x").apply(math_vec_square)
         self.assertEqual(pd_val, swifter_val)  # equality test
 
+    @run_if_ray_installed
     def test_groupby_index_apply(self):
         LOG.info("test_groupby_index_apply")
         SIZE = GROUPBY_MAX_ROWS_PANDAS_DEFAULT * 2
@@ -745,6 +756,7 @@ class TestPandasDataFrame(TestSwifter):
         swifter_val = df.swifter.progress_bar(enable=False).applymap(math_foo)
         self.assertEqual(pd_val, swifter_val)  # equality test
 
+    @run_if_ray_installed
     def test_vectorized_math_groupby_apply_on_small_dataframe(self):
         LOG.info("test_vectorized_math_groupby_apply_on_small_dataframe")
         df = pd.DataFrame(
@@ -758,6 +770,7 @@ class TestPandasDataFrame(TestSwifter):
         swifter_val = df.swifter.groupby("g").apply(numeric_func)
         self.assertSeriesEqual(pd_val, swifter_val, "Swifter output does not equal Pandas output")  # equality test
 
+    @run_if_ray_installed
     def test_vectorized_force_parallel_math_groupby_apply_on_small_dataframe(self):
         LOG.info("test_vectorized_force_parallel_math_groupby_apply_on_small_dataframe")
         df = pd.DataFrame(
@@ -771,6 +784,7 @@ class TestPandasDataFrame(TestSwifter):
         swifter_val = df.swifter.force_parallel(True).groupby("g").apply(numeric_func)
         self.assertSeriesEqual(pd_val, swifter_val, "Swifter output does not equal Pandas output")  # equality test
 
+    @run_if_ray_installed
     def test_vectorized_math_groupby_apply_on_large_dataframe(self):
         LOG.info("test_vectorized_math_groupby_apply_on_large_dataframe")
         df = pd.DataFrame(
@@ -784,6 +798,7 @@ class TestPandasDataFrame(TestSwifter):
         swifter_val = df.swifter.groupby("g").apply(numeric_func)
         self.assertSeriesEqual(pd_val, swifter_val, "Swifter output does not equal Pandas output")  # equality test
 
+    @run_if_ray_installed
     def test_vectorized_math_groupby_apply_on_large_dataframe_index(self):
         LOG.info("test_vectorized_math_groupby_apply_on_large_dataframe_index")
         df = pd.DataFrame(
@@ -797,6 +812,7 @@ class TestPandasDataFrame(TestSwifter):
         swifter_val = df.swifter.groupby(df.index).apply(numeric_func)
         self.assertSeriesEqual(pd_val, swifter_val, "Swifter output does not equal Pandas output")  # equality test
 
+    @run_if_ray_installed
     def test_vectorized_force_parallel_math_groupby_apply_on_large_dataframe(self):
         LOG.info("test_vectorized_force_parallel_math_groupby_apply_on_large_dataframe")
         df = pd.DataFrame(
@@ -810,6 +826,7 @@ class TestPandasDataFrame(TestSwifter):
         swifter_val = df.swifter.force_parallel(True).groupby("g").apply(numeric_func)
         self.assertSeriesEqual(pd_val, swifter_val, "Swifter output does not equal Pandas output")  # equality test
 
+    @run_if_ray_installed
     def test_vectorized_text_groupby_apply_on_small_dataframe(self):
         LOG.info("test_vectorized_text_groupby_apply_on_small_dataframe")
         df = pd.DataFrame(
@@ -819,6 +836,7 @@ class TestPandasDataFrame(TestSwifter):
         swifter_val = df.swifter.groupby("g").apply(clean_text_foo)
         self.assertSeriesEqual(pd_val, swifter_val, "Swifter output does not equal Pandas output")  # equality test
 
+    @run_if_ray_installed
     def test_vectorized_force_parallel_text_groupby_apply_on_small_dataframe(self):
         LOG.info("test_vectorized_force_parallel_text_groupby_apply_on_small_dataframe")
         df = pd.DataFrame(
@@ -828,6 +846,7 @@ class TestPandasDataFrame(TestSwifter):
         swifter_val = df.swifter.force_parallel(True).groupby("g").apply(clean_text_foo)
         self.assertSeriesEqual(pd_val, swifter_val, "Swifter output does not equal Pandas output")  # equality test
 
+    @run_if_ray_installed
     def test_vectorized_text_groupby_apply_on_large_dataframe(self):
         LOG.info("test_vectorized_text_groupby_apply_on_large_dataframe")
         df = pd.DataFrame(
@@ -840,6 +859,7 @@ class TestPandasDataFrame(TestSwifter):
         swifter_val = df.swifter.groupby("g").apply(clean_text_foo)
         self.assertSeriesEqual(pd_val, swifter_val, "Swifter output does not equal Pandas output")  # equality test
 
+    @run_if_ray_installed
     def test_vectorized_force_parallel_text_groupby_apply_on_large_dataframe(self):
         LOG.info("test_vectorized_force_parallel_text_groupby_apply_on_large_dataframe")
         df = pd.DataFrame(


### PR DESCRIPTION
Per #212 , adding a secondary fallback to pandas apply if the first fallback of a dask apply fails (after dask map partitions fails)

This also posed an opportunity to simplify the code a bit by some slight refactoring, so i added that as well